### PR TITLE
Ruby 2.5 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in ruby-openid.gemspec
+gemspec
+
+gem 'rake'
+gem 'test-unit', '>= 2.5.2'
+gem 'activesupport', '5.1.6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,36 @@
+PATH
+  remote: .
+  specs:
+    ruby-openid (2.1.8.2.skroutz)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.1.6.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    concurrent-ruby (1.1.6)
+    i18n (1.8.3)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.1)
+    power_assert (1.2.0)
+    rake (13.0.1)
+    test-unit (3.3.6)
+      power_assert
+    thread_safe (0.3.6)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport (= 5.1.6.2)
+  rake
+  ruby-openid!
+  test-unit (>= 2.5.2)
+
+BUNDLED WITH
+   1.13.6

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,14 @@
+#!/usr/bin/env rake
+require 'bundler/gem_tasks'
+
+require 'rake/testtask'
+
+desc "Run tests"
+Rake::TestTask.new('test') do |t|
+  t.libs << 'lib'
+  t.libs << 'test'
+  t.test_files = FileList["test/**/test_*.rb"]
+  t.verbose = false
+end
+
+task :default => :test

--- a/lib/openid/cryptutil.rb
+++ b/lib/openid/cryptutil.rb
@@ -1,19 +1,7 @@
 require "openid/util"
 require "digest/sha1"
 require "digest/sha2"
-begin
-  require "digest/hmac"
-rescue LoadError
-  begin
-    # Try loading the ruby-hmac files if they exist
-    require "hmac-sha1"
-    require "hmac-sha2"
-  rescue LoadError
-    # Nothing exists use included hmac files
-    require "hmac/sha1"
-    require "hmac/sha2"
-  end
-end
+require "openssl"
 
 module OpenID
   # This module contains everything needed to perform low-level
@@ -37,11 +25,7 @@ module OpenID
     end
 
     def CryptUtil.hmac_sha1(key, text)
-      if Digest.const_defined? :HMAC      
-        Digest::HMAC.new(key,Digest::SHA1).update(text).digest
-      else
-        return HMAC::SHA1.digest(key, text)
-      end
+      OpenSSL::HMAC.hexdigest('sha1', key, text)
     end
 
     def CryptUtil.sha256(text)
@@ -49,11 +33,7 @@ module OpenID
     end
 
     def CryptUtil.hmac_sha256(key, text)
-      if Digest.const_defined? :HMAC      
-        Digest::HMAC.new(key,Digest::SHA256).update(text).digest
-      else
-        return HMAC::SHA256.digest(key, text)
-      end
+      OpenSSL::HMAC.hexdigest('sha256', key, text)
     end
 
     # Generate a random string of the given length, composed of the

--- a/ruby-openid.gemspec
+++ b/ruby-openid.gemspec
@@ -3,7 +3,7 @@ require 'rubygems'
 SPEC = Gem::Specification.new do |s|
   s.name = `cat admin/library-name`.strip
 #  s.version = `darcs changes --tags= | awk '$1 == "tagged" { print $2 }' | head -n 1`.strip
-  s.version = '2.1.8.2.skroutz'
+  s.version = '2.1.8.3.skroutz'
   s.author = 'JanRain, Inc'
   s.email = 'openid@janrain.com'
   s.homepage = 'http://github.com/openid/ruby-openid'

--- a/test/test_accept.rb
+++ b/test/test_accept.rb
@@ -1,5 +1,6 @@
 
 require 'test/unit'
+require 'testutil'
 require 'openid/yadis/accept'
 require 'openid/extras'
 require 'openid/util'

--- a/test/test_consumer.rb
+++ b/test/test_consumer.rb
@@ -1,6 +1,7 @@
 require "openid/consumer"
 require "test/unit"
 require "testutil"
+require 'active_support/core_ext/hash'
 
 module OpenID
   class Consumer


### PR DESCRIPTION
Tests ran with `bundle exec rake test`.

Keep in mind that not all tests pass, but I made sure that the same specs that fail with ruby 2.3, also fail with ruby 2.5.
So as far as ruby 2.5 is concerned this should be fine.

```
835 tests, 6157 assertions, 9 failures, 19 errors, 0 pendings, 0 omissions, 7 notifications
96.6467% passed
```